### PR TITLE
Fix unscoped currentrow which was throwing an error

### DIFF
--- a/modules/cbdebugger/includes/debug.cfm
+++ b/modules/cbdebugger/includes/debug.cfm
@@ -204,7 +204,7 @@ Description :
 				  <cfelse>
 				  	<cfset color = "fw_greenText">
 				  </cfif>
-				  <tr <cfif currentrow mod 2 eq 0>class="even"</cfif>>
+				  <tr <cfif debugTimers.currentrow mod 2 eq 0>class="even"</cfif>>
 				  	<td align="center" >#TimeFormat(debugTimers.timestamp,"hh:MM:SS.l tt")#</td>
 					<td align="center" >#debugTimers.Time# ms</td>
 					<td ><span class="#color#">#debugTimers.Method#</span></td>


### PR DESCRIPTION
I was reading your recent blog post about enabling the debugger and when I did an error was throw - complaining about 'currentrow'.

Messages: variable [CURRENTROW] doesn't exist 
Template: C:\inetpub\wwwroot\railo\planningpointv3\modules\cbdebugger\includes\debug.cfm

I've fixed this to properly reference debugTimers.currentrow and now the debugger works as expected locally.